### PR TITLE
Check if the r parameter is indeed set, before when the tt parameter …

### DIFF
--- a/Controller/Redirect/Index.php
+++ b/Controller/Redirect/Index.php
@@ -82,6 +82,11 @@ class Index extends Action
             return $response->setPath('/');
         }
 
+        // If tt is set but r not, redirect to homepage.
+        if ($this->request->getParam('tt') && !$this->request->getParam('r')) {
+            return $response->setPath('/');
+        }
+
         $domainName = $this->storeManager->getStore()->getBaseUrl(UrlInterface::URL_TYPE_LINK);
 
         // phpcs:ignore Magento2.Functions.DiscouragedFunction


### PR DESCRIPTION
…was set but the r parameter wasn't this resulted in an exception. This is because the urlencode on line 126 does not accept null but required strictly typed strings. To prevent any code from being executed while not needed, I added a check if the r parameter is indeed set.